### PR TITLE
feat: Introduce Start Game API and Refactor DB Initialization with Additional Commands and Tests

### DIFF
--- a/Backend/cmd/app/main.go
+++ b/Backend/cmd/app/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	engine := gin.Default()
 
-	engine.POST("/api/v1/game", gameHandler.CreateGame)
+	engine.POST("/api/v1/games", gameHandler.StartGame)
 	engine.GET("/api/v1/game/:gameId", gameHandler.GetGame)
 	engine.DELETE("/api/v1/game/:gameId", gameHandler.DeleteGame)
 

--- a/Backend/cmd/app/main.go
+++ b/Backend/cmd/app/main.go
@@ -1,48 +1,25 @@
 package main
 
 import (
-	"fmt"
-	"log"
-
-	"os"
-
+	"github.com/Game-as-a-Service/The-Message/database"
+	"github.com/Game-as-a-Service/The-Message/service/service"
 	"github.com/gin-gonic/gin"
 
 	http "github.com/Game-as-a-Service/The-Message/service/delivery/http/v1"
 	repository "github.com/Game-as-a-Service/The-Message/service/repository/mysql"
-	"gorm.io/driver/mysql"
-	"gorm.io/gorm"
-
 	_ "github.com/joho/godotenv/autoload"
 )
 
 func main() {
-	dbHost := os.Getenv("DB_HOST")
-	dbDatabase := os.Getenv("DB_DATABASE")
-	dbUser := os.Getenv("DB_USER")
-	dbPwd := os.Getenv("DB_PASSWORD")
-	dbPort := os.Getenv("DB_PORT")
-
-	db, err := gorm.Open(mysql.Open(fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", dbUser, dbPwd, dbHost, dbPort, dbDatabase)), &gorm.Config{})
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	gameRepo := repository.NewGameRepository(db)
-
-	gameHandler := &http.GameHandler{
-		GameRepo: gameRepo,
-	}
-	db.Table("games").AutoMigrate(&repository.Game{})
+	db := database.InitDB()
 
 	engine := gin.Default()
 
-	engine.POST("/api/v1/games", gameHandler.StartGame)
-	engine.GET("/api/v1/game/:gameId", gameHandler.GetGame)
-	engine.DELETE("/api/v1/game/:gameId", gameHandler.DeleteGame)
+	gameRepo := repository.NewGameRepository(db)
+	playerRepo := repository.NewPlayerRepository(db)
+	gameServ := service.NewGameService(gameRepo, playerRepo)
 
-	engine.Static("/swagger", "./web/swagger-ui")
+	http.NewGameHandler(engine, gameServ)
 
 	engine.Run(":8080")
 }

--- a/Backend/cmd/migrate/main/fresh.go
+++ b/Backend/cmd/migrate/main/fresh.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/Game-as-a-Service/The-Message/database"
+	"gorm.io/gorm"
+)
+
+func main() {
+	db := database.InitDB()
+	tableNames := GetTableNames(db)
+	TruncateTables(db, tableNames)
+}
+
+func GetTableNames(db *gorm.DB) []string {
+	var tableNames []string
+	var rows *sql.Rows
+	var err error
+
+	rows, err = db.Raw("SHOW TABLES").Rows()
+	if err != nil {
+		fmt.Println("Error fetching table names:", err)
+		return tableNames
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tableName string
+		rows.Scan(&tableName)
+		tableNames = append(tableNames, tableName)
+	}
+
+	return tableNames
+}
+
+func TruncateTables(db *gorm.DB, tableNames []string) {
+	for _, tableName := range tableNames {
+		db.Exec(fmt.Sprintf("SET FOREIGN_KEY_CHECKS = 0"))
+		db.Exec(fmt.Sprintf("TRUNCATE TABLE `%s`", tableName))
+		db.Exec(fmt.Sprintf("SET FOREIGN_KEY_CHECKS = 1"))
+	}
+	fmt.Println("All specified tables truncated successfully.")
+}

--- a/Backend/cmd/migrate/main/migrate.go
+++ b/Backend/cmd/migrate/main/migrate.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/Game-as-a-Service/The-Message/database"
+	domain "github.com/Game-as-a-Service/The-Message/service/repository"
+	repository "github.com/Game-as-a-Service/The-Message/service/repository/mysql"
+	"gorm.io/gorm"
+)
+
+func main() {
+	db := database.InitDB()
+	MigrationMysql(db)
+}
+
+func MigrationMysql(db *gorm.DB) {
+	err := db.AutoMigrate(&repository.Game{})
+	if err != nil {
+		return
+	}
+	err = db.AutoMigrate(&repository.Player{})
+	if err != nil {
+		return
+	}
+}
+
+func Migration(db *gorm.DB) {
+	err := db.AutoMigrate(&domain.Game{})
+	if err != nil {
+		return
+	}
+	err = db.AutoMigrate(&domain.Player{})
+	if err != nil {
+		return
+	}
+}

--- a/Backend/database/db.go
+++ b/Backend/database/db.go
@@ -1,0 +1,28 @@
+package database
+
+import (
+	"fmt"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"log"
+)
+
+func InitDB() *gorm.DB {
+	dbHost := "127.0.0.1"   //os.Getenv("DB_HOST")
+	dbDatabase := "message" //os.Getenv("DB_DATABASE")
+	dbUser := "root"        //os.Getenv("DB_USER")
+	dbPwd := ""             //os.Getenv("DB_PASSWORD")
+	dbPort := "3306"        //os.Getenv("DB_PORT")
+
+	var err error
+
+	db, err := gorm.Open(mysql.Open(GetDSN(dbUser, dbPwd, dbHost, dbPort, dbDatabase)), &gorm.Config{})
+	if err != nil {
+		log.Fatal("Cannot connect to database: %v", err)
+	}
+	return db
+}
+
+func GetDSN(user string, password string, host string, port string, database string) string {
+	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", user, password, host, port, database)
+}

--- a/Backend/enums/indentity.go
+++ b/Backend/enums/indentity.go
@@ -1,0 +1,7 @@
+package enums
+
+const (
+	UndercoverFront = "潛伏戰線"
+	MilitaryIntel   = "軍情"
+	Bystander       = "打醬油"
+)

--- a/Backend/service/repository/gameRepository.go
+++ b/Backend/service/repository/gameRepository.go
@@ -12,5 +12,5 @@ type GameRepository interface {
 	GetGameById(ctx context.Context, id int) (*Game, error)
 	CreateGame(ctx context.Context, game *Game) (*Game, error)
 	DeleteGame(ctx context.Context, id int) error
-	GetGameWithPlayers(cxt context.Context, id int) (*Game, error)
+	GetGameWithPlayers(ctx context.Context, id int) (*Game, error)
 }

--- a/Backend/service/repository/gameRepository.go
+++ b/Backend/service/repository/gameRepository.go
@@ -3,12 +3,14 @@ package repository
 import "context"
 
 type Game struct {
-	Id    int `gorm:"primaryKey;auto_increment"`
-	Token string
+	Id      int `gorm:"primaryKey;auto_increment"`
+	Token   string
+	Players []Player
 }
 
 type GameRepository interface {
 	GetGameById(ctx context.Context, id int) (*Game, error)
 	CreateGame(ctx context.Context, game *Game) (*Game, error)
 	DeleteGame(ctx context.Context, id int) error
+	GetGameWithPlayers(cxt context.Context, id int) (*Game, error)
 }

--- a/Backend/service/repository/mysql/mysqlGameRepository.go
+++ b/Backend/service/repository/mysql/mysqlGameRepository.go
@@ -12,6 +12,7 @@ type Game struct {
 	gorm.Model
 	Id        int `gorm:"primaryKey;auto_increment"`
 	Token     string
+	Players   []Player
 	CreatedAt time.Time `gorm:"autoCreateTime"`
 	UpdatedAt time.Time `gorm:"autoCreateTime"`
 	DeletedAt gorm.DeletedAt
@@ -60,4 +61,12 @@ func (p *GameRepository) DeleteGame(ctx context.Context, id int) error {
 	}
 
 	return nil
+}
+
+func (g *GameRepository) GetGameWithPlayers(cxt context.Context, id int) (*repository.Game, error) {
+	var game repository.Game
+	if err := g.db.Preload("Players").First(&game, id).Error; err != nil {
+		return nil, err
+	}
+	return &game, nil
 }

--- a/Backend/service/repository/mysql/mysqlGameRepository.go
+++ b/Backend/service/repository/mysql/mysqlGameRepository.go
@@ -63,7 +63,7 @@ func (p *GameRepository) DeleteGame(ctx context.Context, id int) error {
 	return nil
 }
 
-func (g *GameRepository) GetGameWithPlayers(cxt context.Context, id int) (*repository.Game, error) {
+func (g *GameRepository) GetGameWithPlayers(ctx context.Context, id int) (*repository.Game, error) {
 	var game repository.Game
 	if err := g.db.Preload("Players").First(&game, id).Error; err != nil {
 		return nil, err

--- a/Backend/service/repository/mysql/mysqlPlayerRepository.go
+++ b/Backend/service/repository/mysql/mysqlPlayerRepository.go
@@ -1,0 +1,35 @@
+package mysql
+
+import (
+	"context"
+	domain "github.com/Game-as-a-Service/The-Message/service/repository"
+	repository "github.com/Game-as-a-Service/The-Message/service/repository"
+	"gorm.io/gorm"
+	"time"
+)
+
+type Player struct {
+	gorm.Model
+	Id           int `gorm:"primaryKey;auto_increment"`
+	Name         string
+	GameId       int `gorm:"foreignKey:GameId;references:Id"`
+	IdentityCard string
+	CreatedAt    time.Time `gorm:"autoCreateTime"`
+	UpdatedAt    time.Time `gorm:"autoCreateTime"`
+	DeletedAt    gorm.DeletedAt
+}
+
+type PlayerRepository struct {
+	db *gorm.DB
+}
+
+func NewPlayerRepository(db *gorm.DB) repository.PlayerRepository {
+	return &PlayerRepository{
+		db: db,
+	}
+}
+
+func (p *PlayerRepository) CreatePlayer(cxt context.Context, player *domain.Player) (*domain.Player, error) {
+	err := p.db.Table("players").Create(player).Error
+	return player, err
+}

--- a/Backend/service/repository/mysql/mysqlPlayerRepository.go
+++ b/Backend/service/repository/mysql/mysqlPlayerRepository.go
@@ -29,7 +29,7 @@ func NewPlayerRepository(db *gorm.DB) repository.PlayerRepository {
 	}
 }
 
-func (p *PlayerRepository) CreatePlayer(cxt context.Context, player *domain.Player) (*domain.Player, error) {
+func (p *PlayerRepository) CreatePlayer(ctx context.Context, player *domain.Player) (*domain.Player, error) {
 	err := p.db.Table("players").Create(player).Error
 	return player, err
 }

--- a/Backend/service/repository/playerRepository.go
+++ b/Backend/service/repository/playerRepository.go
@@ -12,5 +12,5 @@ type Player struct {
 }
 
 type PlayerRepository interface {
-	CreatePlayer(cxt context.Context, player *Player) (*Player, error)
+	CreatePlayer(ctx context.Context, player *Player) (*Player, error)
 }

--- a/Backend/service/repository/playerRepository.go
+++ b/Backend/service/repository/playerRepository.go
@@ -1,0 +1,16 @@
+package repository
+
+import (
+	"context"
+)
+
+type Player struct {
+	Id           int `gorm:"primaryKey;auto_increment"`
+	Name         string
+	GameId       int `gorm:"foreignKey:GameId;references:Id"`
+	IdentityCard string
+}
+
+type PlayerRepository interface {
+	CreatePlayer(cxt context.Context, player *Player) (*Player, error)
+}

--- a/Backend/service/request/CreateGameRequest.go
+++ b/Backend/service/request/CreateGameRequest.go
@@ -1,0 +1,10 @@
+package request
+
+type CreateGameRequest struct {
+	Players []PlayerInfo `json:"players"`
+}
+
+type PlayerInfo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}

--- a/Backend/service/service/gameService.go
+++ b/Backend/service/service/gameService.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"github.com/Game-as-a-Service/The-Message/enums"
+	domain "github.com/Game-as-a-Service/The-Message/service/repository"
+	repository "github.com/Game-as-a-Service/The-Message/service/repository"
+	"github.com/Game-as-a-Service/The-Message/service/request"
+	"github.com/gin-gonic/gin"
+	"math/rand"
+)
+
+type GameService struct {
+	GameRepo   repository.GameRepository
+	PlayerRepo repository.PlayerRepository
+}
+
+func NewGameService(gameRepo repository.GameRepository, playerRepo repository.PlayerRepository) *GameService {
+	return &GameService{
+		GameRepo:   gameRepo,
+		PlayerRepo: playerRepo,
+	}
+}
+
+func (g *GameService) StartGame(cxt *gin.Context, req request.CreateGameRequest) (*domain.Game, error) {
+	game := new(domain.Game)
+	jwtToken := "the-message" // 先亂寫Token
+	jwtBytes := []byte(jwtToken)
+	hash := sha256.Sum256(jwtBytes)
+	hashString := hex.EncodeToString(hash[:])
+	game.Token = hashString
+
+	game, err := g.GameRepo.CreateGame(cxt, game)
+	if err != nil {
+		return nil, err
+	}
+
+	// 建立身份牌牌堆
+	identityCards := initIdentityCards(len(req.Players))
+
+	for i, reqPlayer := range req.Players {
+		player := new(domain.Player)
+		player.Name = reqPlayer.Name
+		player.GameId = game.Id
+		player.IdentityCard = identityCards[i]
+		player, err = g.PlayerRepo.CreatePlayer(cxt, player)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return game, err
+}
+
+func initIdentityCards(count int) []string {
+	identityCards := make([]string, count)
+	// if count == 3 had 1 UndercoverFront, 1 MilitaryIntel, 1 Bystander
+	if count == 3 {
+		identityCards[0] = enums.UndercoverFront
+		identityCards[1] = enums.MilitaryIntel
+		identityCards[2] = enums.Bystander
+	}
+	identityCards = shuffle(identityCards)
+	return identityCards
+}
+
+func shuffle(cards []string) []string {
+	shuffledCards := make([]string, len(cards))
+	for i, j := range rand.Perm(len(cards)) {
+		shuffledCards[i] = cards[j]
+	}
+	return shuffledCards
+}

--- a/Backend/tests/acceptance/game_test.go
+++ b/Backend/tests/acceptance/game_test.go
@@ -1,0 +1,106 @@
+package acceptance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"github.com/Game-as-a-Service/The-Message/database"
+	handler "github.com/Game-as-a-Service/The-Message/service/delivery/http/v1"
+	repository "github.com/Game-as-a-Service/The-Message/service/repository"
+	mysqlRepo "github.com/Game-as-a-Service/The-Message/service/repository/mysql"
+	"github.com/Game-as-a-Service/The-Message/service/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+var serverURL string
+var gameRepo repository.GameRepository
+
+func TestMain(m *testing.M) {
+	testDB := database.InitDB()
+
+	engine := gin.Default()
+
+	gameRepo = mysqlRepo.NewGameRepository(testDB)
+	playerRepo := mysqlRepo.NewPlayerRepository(testDB)
+	gameServ := service.NewGameService(gameRepo, playerRepo)
+
+	handler.NewGameHandler(engine, gameServ)
+
+	server := httptest.NewServer(engine)
+	serverURL = server.URL
+
+	code := m.Run()
+	defer server.Close()
+	os.Exit(code)
+}
+
+type Player struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Request struct {
+	Players []Player `json:"players"`
+}
+
+func TestGive3PlayersABC_whenStartGame_thenABCHadIdentityCard(t *testing.T) {
+
+	players := []Player{
+		{ID: "6497f6f226b40d440b9a90cc", Name: "A"},
+		{ID: "6498112b26b40d440b9a90ce", Name: "B"},
+		{ID: "6499df157fed0c21a4fd0425", Name: "C"},
+	}
+	requestBody := Request{Players: players}
+
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Fatalf("Failed to marshal JSON: %v", err)
+	}
+
+	api := "/api/v1/games"
+	resp := request(t, api, jsonBody)
+
+	assert.Equal(t, 200, resp.StatusCode)
+
+	responseJson := response(t, resp)
+
+	assert.NotNil(t, responseJson["Token"], "JSON response should contain a 'Token' field")
+	assert.NotNil(t, responseJson["Id"], "JSON response should contain a 'Id' field")
+
+	// 驗證Game內的玩家都持有identity
+	game, _ := gameRepo.GetGameWithPlayers(context.TODO(), int(responseJson["Id"].(float64)))
+	assert.NotEmpty(t, game.Players[0].IdentityCard)
+	assert.NotEmpty(t, game.Players[1].IdentityCard)
+	assert.NotEmpty(t, game.Players[2].IdentityCard)
+}
+
+func response(t *testing.T, resp *http.Response) map[string]interface{} {
+	var responseMap map[string]interface{}
+	err := json.NewDecoder(resp.Body).Decode(&responseMap)
+	if err != nil {
+		t.Fatalf("Failed to decode JSON: %v", err)
+	}
+	return responseMap
+}
+
+func request(t *testing.T, api string, jsonBody []byte) *http.Response {
+	req, err := http.NewRequest(http.MethodPost, serverURL+api, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+
+	client := &http.Client{}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return resp
+}


### PR DESCRIPTION
## Why need this change? / Root cause:
- Add Start Game API with E2E tests
- The current codebase had database initialization tangled with other parts of the application, which makes it difficult to maintain and scale.
- Ensuring robustness of the application with acceptance tests.

## Changes made:
- Introduced a new 'start game' API, enabling players to initiate gameplay.
- Refactored the code to separate database initialization and introduce a dedicated service layer for better separation of concerns.
- Implemented basic migrate and fresh commands to offer better control and management of the database.
- Introduced a basic acceptance test to ensure that the main flows of the game function correctly.
## Test Scope / Change impact:
- E2E tests for the 'start game' API ensuring its proper functionality.
- Tests for the new database management commands verifying their expected behaviors.
- Acceptance test covering the game's primary flows and interactions.