### PR TITLE
ci: fix acceptance test can't work after PR merged

### DIFF
--- a/.github/workflows/test-go-unit.yml
+++ b/.github/workflows/test-go-unit.yml
@@ -1,4 +1,4 @@
-name: Backend CI
+name: ⚙️ Backend CI
 
 on:
   push:
@@ -17,17 +17,6 @@ jobs:
   build:
 
     runs-on: ubuntu-22.04
-
-    services:
-      mysql:
-        image: mysql:8.1.0
-        env:
-          MYSQL_ROOT_PASSWORD: ${{ secrets.DB_ROOT_PASSWORD }}
-          MYSQL_DATABASE: test
-          MYSQL_USER: user
-          MYSQL_PASSWORD: ${{ secrets.DB_PASSWORD }}
-        ports:
-          - "3306:3306"
 
     steps:
       - uses: actions/checkout@v3
@@ -56,7 +45,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Test
+      - name: 🧪 Test
         working-directory: ./Backend
         run: go test $(go list ./... | grep -v /tests/) -count=1 -v  -coverprofile=unit_test_coverage.out
 
@@ -68,7 +57,19 @@ jobs:
 
   acceptance_test:
     needs: unit_test
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: github.event_name == 'push'
+
+    services:
+      mysql:
+        image: mysql:8.1.0
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.DB_ROOT_PASSWORD }}
+          MYSQL_DATABASE: test
+          MYSQL_USER: user
+          MYSQL_PASSWORD: ${{ secrets.DB_PASSWORD }}
+        ports:
+          - "3306:3306"
+    
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
@@ -78,11 +79,14 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Env handle
+        working-directory: ./Backend
+        run: cp env .env
 
       - name: Migration
         working-directory: ./Backend
         run: go run ./cmd/migrate/migrate.go
-      - name: Acceptance test
+      - name: 🎯 Acceptance test
         working-directory: ./Backend
         run: go test ./... -v -count=1 -coverprofile=coverage.out
 


### PR DESCRIPTION
## Why need this change? / Root cause:
- The acceptance test cannot run successfully after the PR is merged.

## Changes made:
- Modify the backend CI pipeline to execute when github.event_name == 'push'.

## Test Scope / Change impact:
- 

