### PR TITLE
Chore: Added Github Actions to wait for MySQL to start and modify the mysql version to the median during acceptance_test

### DIFF
--- a/.github/workflows/test-go-unit.yml
+++ b/.github/workflows/test-go-unit.yml
@@ -68,7 +68,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8.1.0
+        image: mysql:8.1
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.DB_ROOT_PASSWORD }}
           MYSQL_DATABASE: test
@@ -89,6 +89,12 @@ jobs:
       - name: Env handle
         working-directory: ./Backend
         run: cp env .env
+
+      - name: Wait for MySQL
+        run: |
+          wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
+          chmod +x wait-for-it.sh
+          ./wait-for-it.sh 127.0.0.1:3306 --timeout=60
 
       - name: Migration
         working-directory: ./Backend


### PR DESCRIPTION
### Why need this change? / Root cause:

To ensure that the MySQL service is fully operational before running tests in the Github Actions env.

### Changes made:

Added a step in `.github/workflows/test-go-unit.yml` to wait for MySQL to start.

### Test Scope / Change impact:

 This change affects only the CI/CD pipeline.