### PR TITLE
Fix An incorrect file path is read when initiating the test

### DIFF
--- a/Backend/config/migration.go
+++ b/Backend/config/migration.go
@@ -70,6 +70,7 @@ func RunRefresh() {
 
 func GetSourceURL() string {
 	dir, _ := os.Getwd()
+	dir = strings.SplitAfter(dir, "Backend")[0]
 	dir = strings.ReplaceAll(dir, "\\", "/")
 
 	sourceURL := "file://" + dir + "/database/migrations"


### PR DESCRIPTION
## Why need this change? / Root cause:
- In the past, when acquiring Migrations files, the wrong path would be captured during testing, forcing the acquisition of the migrations folder based on the current directory structure.

## Changes made:
- Used strings.SplitAfter() to obtain the location of the Backend folder.

## Test Scope / Change impact:
- Starting the backend service and running integration tests.

## Issue:
None