### PR TITLE
Feat: add migrations charset

### DIFF
--- a/Backend/database/migrations/000001_create_games_table.up.sql
+++ b/Backend/database/migrations/000001_create_games_table.up.sql
@@ -7,6 +7,6 @@ CREATE TABLE games
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,
     deleted_at DATETIME
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 COMMIT;

--- a/Backend/database/migrations/000002_create_players_table.up.sql
+++ b/Backend/database/migrations/000002_create_players_table.up.sql
@@ -10,6 +10,6 @@ CREATE TABLE players
     updated_at    DATETIME     NOT NULL,
     deleted_at    DATETIME,
     FOREIGN KEY (game_id) REFERENCES games (id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 COMMIT;

--- a/Backend/database/migrations/000003_create_cards_table.up.sql
+++ b/Backend/database/migrations/000003_create_cards_table.up.sql
@@ -8,6 +8,6 @@ CREATE TABLE cards
     created_at DATETIME     NOT NULL,
     updated_at DATETIME     NOT NULL,
     deleted_at DATETIME
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 COMMIT;

--- a/Backend/database/migrations/000004_create_decks_table.up.sql
+++ b/Backend/database/migrations/000004_create_decks_table.up.sql
@@ -8,6 +8,6 @@ CREATE TABLE decks
     created_at DATETIME     NOT NULL,
     updated_at DATETIME     NOT NULL,
     deleted_at DATETIME
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 COMMIT;

--- a/Backend/database/migrations/000005_create_player_cards_table.up.sql
+++ b/Backend/database/migrations/000005_create_player_cards_table.up.sql
@@ -13,6 +13,6 @@ CREATE TABLE player_cards
     FOREIGN KEY (player_id) REFERENCES players (id),
     FOREIGN KEY (game_id) REFERENCES games (id),
     FOREIGN KEY (card_id) REFERENCES cards (id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 COMMIT;


### PR DESCRIPTION
## Why need this change? / Root cause:
- To avoid not using utf8 when creating migrations.

## Changes made:
- Added CHARSET, COLLATE to all migrations.

## Test Scope / Change impact:
- Database structure after creating migration.

## Issue:
None