### PR TITLE
Feat: Added api for transmit intelligence card by #95

### DIFF
--- a/Backend/enums/intelligence_types.go
+++ b/Backend/enums/intelligence_types.go
@@ -1,0 +1,20 @@
+package enums
+
+const (
+	SecretTelegram = 1
+	DIRECT         = 2
+	DOCUMENT       = 3
+)
+
+func ToString(secretTelegramType int) string {
+	switch secretTelegramType {
+	case SecretTelegram:
+		return "密電"
+	case DIRECT:
+		return "直達"
+	case DOCUMENT:
+		return "文件"
+	default:
+		return ""
+	}
+}

--- a/Backend/service/delivery/http/v1/player_handler.go
+++ b/Backend/service/delivery/http/v1/player_handler.go
@@ -2,12 +2,12 @@ package http
 
 import (
 	"fmt"
+	"github.com/Game-as-a-Service/The-Message/enums"
 	"github.com/Game-as-a-Service/The-Message/service/request"
-	"net/http"
-	"strconv"
-
 	"github.com/Game-as-a-Service/The-Message/service/service"
 	"github.com/gin-gonic/gin"
+	"net/http"
+	"strconv"
 )
 
 type PlayerHandler struct {
@@ -31,6 +31,7 @@ func RegisterPlayerHandler(opts *PlayerHandlerOptions) {
 	}
 
 	opts.Engine.POST("/api/v1/players/:playerId/player-cards", handler.PlayCard)
+	opts.Engine.POST("/api/v1/player/:playerId/transmit-intelligence", handler.TransmitIntelligence)
 }
 
 // PlayCard godoc
@@ -68,5 +69,58 @@ func (p *PlayerHandler) PlayCard(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"result": true,
+	})
+}
+
+// TransmitIntelligence godoc
+// @Summary Transmit intelligence
+// @Description Transmit an intelligence card
+// @Tags players
+// @Accept json
+// @Produce json
+// @Param playerId path int true "Player ID"
+// @Param card_id body request.PlayCardRequest true "Card ID"
+// @Param intelligence_type body request.PlayCardRequest true "Intelligence Type"
+// @Success 200 {object} request.PlayCardResponse
+// @Router /api/v1/player/{playerId}/transmit-intelligence [post]
+func (p *PlayerHandler) TransmitIntelligence(c *gin.Context) {
+	playerId, _ := strconv.Atoi(c.Param("playerId"))
+	var req request.PlayCardRequest
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+
+	intelligenceType := enums.ToString(req.IntelligenceType)
+
+	if intelligenceType == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid intelligence type"})
+		return
+	}
+
+	player, err := p.playerService.GetPlayerById(c, playerId)
+
+	if err != nil || player == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Player not found"})
+		return
+	}
+
+	// Check card_id exists in player_cards
+	exist, err := p.playerService.CheckPlayerCardExist(c, playerId, player.GameId, req.CardID)
+	if err != nil || !exist {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Card not found"})
+		return
+	}
+
+	ret, err := p.playerService.TransmitIntelligenceCard(c, playerId, player.GameId, req.CardID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Failed to transmit intelligence"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"result":  ret,
+		"message": enums.ToString(req.IntelligenceType) + " intelligence transmitted",
 	})
 }

--- a/Backend/service/delivery/http/v1/player_handler.go
+++ b/Backend/service/delivery/http/v1/player_handler.go
@@ -115,7 +115,7 @@ func (p *PlayerHandler) TransmitIntelligence(c *gin.Context) {
 
 	ret, err := p.playerService.TransmitIntelligenceCard(c, playerId, player.GameId, req.CardID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"message": "Failed to transmit intelligence"})
+		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 		return
 	}
 

--- a/Backend/service/repository/mysql/player_card_repository.go
+++ b/Backend/service/repository/mysql/player_card_repository.go
@@ -2,7 +2,7 @@ package mysql
 
 import (
 	"context"
-
+	"errors"
 	"github.com/Game-as-a-Service/The-Message/service/repository"
 	"gorm.io/gorm"
 )
@@ -15,30 +15,6 @@ func NewPlayerCardRepository(db *gorm.DB) *PlayerCardRepository {
 	return &PlayerCardRepository{
 		db: db,
 	}
-}
-
-func (p PlayerCardRepository) GetPlayerCardById(ctx context.Context, id int) (*repository.PlayerCard, error) {
-	card := new(repository.PlayerCard)
-
-	result := p.db.First(&card, "id = ?", id)
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return card, nil
-}
-
-func (p PlayerCardRepository) GetPlayerCardsByGameId(ctx context.Context, id int) ([]*repository.PlayerCard, error) {
-	var cards []*repository.PlayerCard
-
-	result := p.db.Find(&cards, "game_id = ?", id)
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return cards, nil
 }
 
 func (p PlayerCardRepository) CreatePlayerCard(ctx context.Context, card *repository.PlayerCard) (*repository.PlayerCard, error) {
@@ -63,6 +39,41 @@ func (p PlayerCardRepository) DeletePlayerCard(ctx context.Context, id int) erro
 	return nil
 }
 
+func (p PlayerCardRepository) DeletePlayerCardByPlayerIdAndCardId(ctx context.Context, playerId int, gameId int, cardId int) (bool, error) {
+	card := new(repository.PlayerCard)
+
+	result := p.db.Delete(&card, "player_id = ? AND game_id = ? AND card_id = ?", playerId, gameId, cardId)
+	if result.Error != nil {
+		return false, result.Error
+	}
+
+	return true, nil
+}
+
+func (p *PlayerCardRepository) ExistPlayerCardByPlayerIdAndCardId(ctx context.Context, playerId int, gameId int, cardId int) (bool, error) {
+	var card repository.PlayerCard
+	result := p.db.First(&card, "player_id = ? AND game_id = ? AND card_id = ?", playerId, gameId, cardId)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, result.Error
+	}
+	return true, nil
+}
+
+func (p PlayerCardRepository) GetPlayerCardById(ctx context.Context, id int) (*repository.PlayerCard, error) {
+	card := new(repository.PlayerCard)
+
+	result := p.db.First(&card, "id = ?", id)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return card, nil
+}
+
 func (p *PlayerCardRepository) GetPlayerCards(ctx context.Context, playerCard *repository.PlayerCard) (*[]repository.PlayerCard, error) {
 	var playerCards *[]repository.PlayerCard
 	result := p.db.Model(&repository.PlayerCard{}).Preload("Card").Where(&playerCard).Find(&playerCards)
@@ -71,4 +82,16 @@ func (p *PlayerCardRepository) GetPlayerCards(ctx context.Context, playerCard *r
 	}
 
 	return playerCards, nil
+}
+
+func (p PlayerCardRepository) GetPlayerCardsByGameId(ctx context.Context, id int) ([]*repository.PlayerCard, error) {
+	var cards []*repository.PlayerCard
+
+	result := p.db.Find(&cards, "game_id = ?", id)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return cards, nil
 }

--- a/Backend/service/repository/player_card_repository.go
+++ b/Backend/service/repository/player_card_repository.go
@@ -2,9 +2,8 @@ package repository
 
 import (
 	"context"
-	"time"
-
 	"gorm.io/gorm"
+	"time"
 )
 
 type PlayerCard struct {
@@ -26,5 +25,7 @@ type PlayerCardRepository interface {
 	GetPlayerCardsByGameId(ctx context.Context, id int) ([]*PlayerCard, error)
 	CreatePlayerCard(ctx context.Context, card *PlayerCard) (*PlayerCard, error)
 	DeletePlayerCard(ctx context.Context, id int) error
+	DeletePlayerCardByPlayerIdAndCardId(ctx context.Context, playerId int, gameId int, cardId int) (bool, error)
+	ExistPlayerCardByPlayerIdAndCardId(ctx context.Context, playerId int, gameId int, cardId int) (bool, error)
 	GetPlayerCards(ctx context.Context, playerCard *PlayerCard) (*[]PlayerCard, error)
 }

--- a/Backend/service/request/game_request.go
+++ b/Backend/service/request/game_request.go
@@ -19,5 +19,6 @@ type PlayCardResponse struct {
 }
 
 type PlayCardRequest struct {
-	CardID int `json:"card_id"`
+	CardID           int `json:"card_id"`
+	IntelligenceType int `json:"intelligence_type"`
 }

--- a/Backend/service/service/game_service.go
+++ b/Backend/service/service/game_service.go
@@ -155,7 +155,7 @@ func (g *GameService) NextPlayer(c *gin.Context, player *repository.Player) (*re
 	return player.Game, nil
 }
 
-func (g *GameService) UpdateStatus(c *gin.Context, game *repository.Game, stage string) {
+func (g *GameService) UpdateStatus(c context.Context, game *repository.Game, stage string) {
 	game.Status = stage
 	err := g.GameRepo.UpdateGame(c, game)
 	if err != nil {

--- a/Backend/service/service/player_service.go
+++ b/Backend/service/service/player_service.go
@@ -70,8 +70,50 @@ func (p *PlayerService) ShuffleIdentityCards(cards []string) []string {
 	return shuffledCards
 }
 
+func (p *PlayerService) CanPlayCard(c *gin.Context, player *repository.Player, cardId int) (bool, error) {
+	if player.Game.Status == enums.GameEnd {
+		return false, errors.New("遊戲已結束")
+	}
+
+	if player.Status == enums.PlayerStatusDead {
+		return false, errors.New("你已死亡")
+	}
+
+	if player.Game.CurrentPlayerId != player.Id {
+		return false, errors.New("尚未輪到你出牌")
+	}
+
+	return true, nil
+}
+
+func (p *PlayerService) CheckPlayerCardExist(c context.Context, playerId int, gameId int, cardId int) (bool, error) {
+	exist, err := p.PlayerCardRepo.ExistPlayerCardByPlayerIdAndCardId(c, playerId, gameId, cardId)
+
+	if err != nil {
+		return false, err
+	}
+
+	return exist, nil
+}
+
 func (p *PlayerService) CreatePlayer(c context.Context, player *repository.Player) (*repository.Player, error) {
 	player, err := p.PlayerRepo.CreatePlayer(c, player)
+	if err != nil {
+		return nil, err
+	}
+	return player, nil
+}
+
+func (p *PlayerService) CreatePlayerCard(c context.Context, card *repository.PlayerCard) error {
+	_, err := p.PlayerCardRepo.CreatePlayerCard(c, card)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *PlayerService) GetPlayerById(c context.Context, id int) (*repository.Player, error) {
+	player, err := p.PlayerRepo.GetPlayer(c, id)
 	if err != nil {
 		return nil, err
 	}
@@ -86,12 +128,13 @@ func (p *PlayerService) GetPlayersByGameId(c context.Context, id int) ([]*reposi
 	return players, nil
 }
 
-func (p *PlayerService) CreatePlayerCard(c context.Context, card *repository.PlayerCard) error {
-	_, err := p.PlayerCardRepo.CreatePlayerCard(c, card)
-	if err != nil {
-		return err
+func (p *PlayerService) GetHandCardId(player *repository.Player, cardId int) (*repository.PlayerCard, error) {
+	for _, card := range player.PlayerCards {
+		if card.CardId == cardId && card.Type == "hand" {
+			return &card, nil
+		}
 	}
-	return nil
+	return nil, errors.New("找不到手牌")
 }
 
 func (p *PlayerService) PlayCard(c *gin.Context, playerId int, cardId int) (*repository.Game, *repository.Card, error) {
@@ -128,27 +171,12 @@ func (p *PlayerService) PlayCard(c *gin.Context, playerId int, cardId int) (*rep
 	return game, &handCard.Card, nil
 }
 
-func (p *PlayerService) CanPlayCard(c *gin.Context, player *repository.Player, cardId int) (bool, error) {
-	if player.Game.Status == enums.GameEnd {
-		return false, errors.New("遊戲已結束")
+func (p *PlayerService) TransmitIntelligenceCard(c *gin.Context, playerId int, gameId int, cardId int) (bool, error) {
+	ret, err := p.PlayerCardRepo.DeletePlayerCardByPlayerIdAndCardId(c, playerId, gameId, cardId)
+
+	if err != nil {
+		return false, err
 	}
 
-	if player.Status == enums.PlayerStatusDead {
-		return false, errors.New("你已死亡")
-	}
-
-	if player.Game.CurrentPlayerId != player.Id {
-		return false, errors.New("尚未輪到你出牌")
-	}
-
-	return true, nil
-}
-
-func (p *PlayerService) GetHandCardId(player *repository.Player, cardId int) (*repository.PlayerCard, error) {
-	for _, card := range player.PlayerCards {
-		if card.CardId == cardId && card.Type == "hand" {
-			return &card, nil
-		}
-	}
-	return nil, errors.New("找不到手牌")
+	return ret, nil
 }

--- a/Backend/tests/e2e/suite_test.go
+++ b/Backend/tests/e2e/suite_test.go
@@ -160,6 +160,11 @@ func (suite *IntegrationTestSuite) TearDownSuite() {
 
 func (suite *IntegrationTestSuite) SetupTest() {
 	suite.tx = suite.db.Begin()
+
+	//Fixme Run db refresh and seeders
+	config.RunRefresh()
+	db := config.NewDatabase()
+	seeders.Run(db)
 }
 
 func (suite *IntegrationTestSuite) TearDownTest() {


### PR DESCRIPTION
### Why need this change? / Root cause:
The game required a feature to transmit intelligence cards by #95 

### Changes made:
In this branch, we have added the ability for players to transmit intelligence cards (SSE functionality not included). This includes the necessary API endpoints, service logic, and repository methods. The changes are mainly in the `player_handler.go`, `player_service.go`, and `player_card_repository.go` files.  

#### The following commits were made:  
- `Test: Added transmit intelligence card e2e test`: This commit adds an end-to-end test for the new feature. The test ensures that the API endpoint for transmitting intelligence cards works as expected.
- `Feat: Added api for transmit intelligence card`: This commit implements the API endpoint for transmitting intelligence cards. It includes the necessary request handling, service logic, and database operations.

### Test Scope / Change impact:
The changes have been thoroughly tested with end-to-end tests to ensure that the new feature works as expected and does not introduce any regressions. The impact of these changes is limited to the player's ability to transmit intelligence cards, and does not affect other parts of the application.
