### PR TITLE
Feat: add intelligence card feature in game progresses table

### DIFF
--- a/Backend/cmd/app/main.go
+++ b/Backend/cmd/app/main.go
@@ -26,6 +26,7 @@ func main() {
 	cardRepo := mysqlRepo.NewCardRepository(db)
 	deckRepo := mysqlRepo.NewDeckRepository(db)
 	playerCardRepo := mysqlRepo.NewPlayerCardRepository(db)
+	gameProgressRepo := mysqlRepo.NewGameProgressRepository(db)
 
 	cardService := service.NewCardService(&service.CardServiceOptions{
 		CardRepo:       cardRepo,
@@ -40,9 +41,10 @@ func main() {
 	})
 
 	playerService := service.NewPlayerService(&service.PlayerServiceOptions{
-		PlayerRepo:     playerRepo,
-		PlayerCardRepo: playerCardRepo,
-		GameRepo:       gameRepo,
+		PlayerRepo:       playerRepo,
+		PlayerCardRepo:   playerCardRepo,
+		GameRepo:         gameRepo,
+		GameProgressRepo: gameProgressRepo,
 	})
 
 	gameService := service.NewGameService(

--- a/Backend/enums/game_action.go
+++ b/Backend/enums/game_action.go
@@ -1,0 +1,5 @@
+package enums
+
+const (
+	TransmitIntelligence = "傳情報"
+)

--- a/Backend/service/repository/game_progresses_repository.go
+++ b/Backend/service/repository/game_progresses_repository.go
@@ -1,0 +1,23 @@
+package repository
+
+import (
+	"context"
+	"gorm.io/gorm"
+	"time"
+)
+
+type GameProgresses struct {
+	Id             int `gorm:"primaryKey;auto_increment"`
+	PlayerId       int
+	GameId         int
+	CardId         int
+	Action         string
+	TargetPlayerId int
+	CreatedAt      time.Time `gorm:"autoCreateTime"`
+	UpdatedAt      time.Time `gorm:"autoCreateTime"`
+	DeletedAt      gorm.DeletedAt
+}
+
+type GameProgressesRepository interface {
+	CreateGameProgress(c context.Context, gameProgress *GameProgresses) (*GameProgresses, error)
+}

--- a/Backend/service/repository/mysql/game_process_repository.go
+++ b/Backend/service/repository/mysql/game_process_repository.go
@@ -1,0 +1,27 @@
+package mysql
+
+import (
+	"context"
+	"github.com/Game-as-a-Service/The-Message/service/repository"
+	"gorm.io/gorm"
+)
+
+type GameProgressRepository struct {
+	db *gorm.DB
+}
+
+func NewGameProgressRepository(db *gorm.DB) *GameProgressRepository {
+	return &GameProgressRepository{
+		db: db,
+	}
+}
+
+func (g *GameProgressRepository) CreateGameProgress(c context.Context, gameProgress *repository.GameProgresses) (*repository.GameProgresses, error) {
+	result := g.db.Create(&gameProgress)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return gameProgress, nil
+}

--- a/Backend/service/service/player_service.go
+++ b/Backend/service/service/player_service.go
@@ -11,25 +11,28 @@ import (
 )
 
 type PlayerService struct {
-	PlayerRepo     repository.PlayerRepository
-	PlayerCardRepo repository.PlayerCardRepository
-	GameRepo       repository.GameRepository
-	GameServ       *GameService
+	PlayerRepo       repository.PlayerRepository
+	PlayerCardRepo   repository.PlayerCardRepository
+	GameRepo         repository.GameRepository
+	GameServ         *GameService
+	GameProgressRepo repository.GameProgressesRepository
 }
 
 type PlayerServiceOptions struct {
-	PlayerRepo     repository.PlayerRepository
-	PlayerCardRepo repository.PlayerCardRepository
-	GameRepo       repository.GameRepository
-	GameServ       *GameService
+	PlayerRepo       repository.PlayerRepository
+	PlayerCardRepo   repository.PlayerCardRepository
+	GameRepo         repository.GameRepository
+	GameServ         *GameService
+	GameProgressRepo repository.GameProgressesRepository
 }
 
 func NewPlayerService(opts *PlayerServiceOptions) PlayerService {
 	return PlayerService{
-		PlayerRepo:     opts.PlayerRepo,
-		PlayerCardRepo: opts.PlayerCardRepo,
-		GameRepo:       opts.GameRepo,
-		GameServ:       opts.GameServ,
+		PlayerRepo:       opts.PlayerRepo,
+		PlayerCardRepo:   opts.PlayerCardRepo,
+		GameRepo:         opts.GameRepo,
+		GameServ:         opts.GameServ,
+		GameProgressRepo: opts.GameProgressRepo,
 	}
 }
 
@@ -188,7 +191,6 @@ func (p *PlayerService) TransmitIntelligenceCard(c *gin.Context, playerId int, g
 	}
 
 	ret, err := p.PlayerCardRepo.DeletePlayerCardByPlayerIdAndCardId(c, playerId, gameId, cardId)
-
 	if err != nil {
 		return false, err
 	}
@@ -197,6 +199,14 @@ func (p *PlayerService) TransmitIntelligenceCard(c *gin.Context, playerId int, g
 	if err != nil {
 		return false, err
 	}
+
+	_, err = p.GameProgressRepo.CreateGameProgress(c, &repository.GameProgresses{
+		GameId:         game.Id,
+		PlayerId:       playerId,
+		CardId:         cardId,
+		Action:         enums.TransmitIntelligence,
+		TargetPlayerId: game.CurrentPlayerId,
+	})
 
 	return ret, nil
 }

--- a/Backend/tests/e2e/suite_test.go
+++ b/Backend/tests/e2e/suite_test.go
@@ -84,6 +84,7 @@ func (suite *IntegrationTestSuite) SetupSuite() {
 	cardRepo := mysqlRepo.NewCardRepository(db)
 	deckRepo := mysqlRepo.NewDeckRepository(db)
 	playerCardRepo := mysqlRepo.NewPlayerCardRepository(db)
+	gameProgressRepo := mysqlRepo.NewGameProgressRepository(db)
 
 	cardService := service.NewCardService(&service.CardServiceOptions{
 		CardRepo:       cardRepo,
@@ -98,9 +99,10 @@ func (suite *IntegrationTestSuite) SetupSuite() {
 	})
 
 	playerService := service.NewPlayerService(&service.PlayerServiceOptions{
-		PlayerRepo:     playerRepo,
-		PlayerCardRepo: playerCardRepo,
-		GameRepo:       gameRepo,
+		PlayerRepo:       playerRepo,
+		PlayerCardRepo:   playerCardRepo,
+		GameRepo:         gameRepo,
+		GameProgressRepo: gameProgressRepo,
 	})
 
 	gameService := service.NewGameService(


### PR DESCRIPTION
### Why need this change? / Root cause:
- Write the intelligence in-game progress table #95

### Changes made:
- Write the intelligence in the game progress table, so that the player can know the intelligence in the game progress table when they transmit the intelligence card.

### Test Scope / Change impact:
- After the transmit-intelligence API, we can check the intelligence card in the game progress table.