### PR TITLE
Feat: Added intelligence_type to cards table and updated TransmitIntelligence API

### DIFF
--- a/Backend/database/migrations/000007_add_intelligence_type_to_cards_table.down.sql
+++ b/Backend/database/migrations/000007_add_intelligence_type_to_cards_table.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE cards DROP COLUMN intelligence_type;
+
+COMMIT;

--- a/Backend/database/migrations/000007_add_intelligence_type_to_cards_table.up.sql
+++ b/Backend/database/migrations/000007_add_intelligence_type_to_cards_table.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE cards ADD COLUMN intelligence_type TINYINT COMMENT '1 密電, 2 直達, 3 文件' AFTER color;
+
+COMMIT;

--- a/Backend/database/seeders/game_card_seeder.go
+++ b/Backend/database/seeders/game_card_seeder.go
@@ -2,6 +2,7 @@ package seeders
 
 import (
 	"context"
+
 	"github.com/Game-as-a-Service/The-Message/enums"
 	"github.com/Game-as-a-Service/The-Message/service/repository"
 	"github.com/Game-as-a-Service/The-Message/service/repository/mysql"
@@ -25,8 +26,9 @@ func SeederCards(db *gorm.DB) {
 		for color, count := range colors {
 			for i := 0; i < count; i++ {
 				mysql.NewCardRepository(db).CreateCard(context.TODO(), &repository.Card{
-					Name:  actionType,
-					Color: color,
+					Name:             actionType,
+					Color:            color,
+					IntelligenceType: enums.ToIntelligenceType(actionType),
 				})
 			}
 		}

--- a/Backend/enums/game_cards.go
+++ b/Backend/enums/game_cards.go
@@ -6,8 +6,21 @@ const (
 	Probe       = "試探"
 	Intercept   = "截獲"
 	Decipher    = "破譯"
-	Diversion   = "轉移"
+	Diversion   = "退回"
 	Burn        = "燒毀"
 	BlurOfTruth = "真偽莫辯"
 	SeeThrough  = "識破"
 )
+
+func ToIntelligenceType(actionType string) int {
+	switch actionType {
+	case LockOn, LureAway, Probe, Decipher:
+		return SecretTelegram
+	case Intercept, Burn, SeeThrough:
+		return Direct
+	case Diversion, BlurOfTruth:
+		return Document
+	default:
+		return 0
+	}
+}

--- a/Backend/enums/intelligence_types.go
+++ b/Backend/enums/intelligence_types.go
@@ -2,17 +2,17 @@ package enums
 
 const (
 	SecretTelegram = 1
-	DIRECT         = 2
-	DOCUMENT       = 3
+	Direct         = 2
+	Document       = 3
 )
 
 func ToString(secretTelegramType int) string {
 	switch secretTelegramType {
 	case SecretTelegram:
 		return "密電"
-	case DIRECT:
+	case Direct:
 		return "直達"
-	case DOCUMENT:
+	case Document:
 		return "文件"
 	default:
 		return ""

--- a/Backend/service/delivery/http/v1/player_handler.go
+++ b/Backend/service/delivery/http/v1/player_handler.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/Game-as-a-Service/The-Message/enums"
 	"github.com/Game-as-a-Service/The-Message/service/request"
 	"github.com/Game-as-a-Service/The-Message/service/service"
 	"github.com/gin-gonic/gin"
@@ -82,7 +81,6 @@ func (p *PlayerHandler) PlayCard(c *gin.Context) {
 // @Produce json
 // @Param playerId path int true "Player ID"
 // @Param card_id body request.PlayCardRequest true "Card ID"
-// @Param intelligence_type body request.PlayCardRequest true "Intelligence Type"
 // @Success 200 {object} request.PlayCardResponse
 // @Router /api/v1/player/{playerId}/transmit-intelligence [post]
 func (p *PlayerHandler) TransmitIntelligence(c *gin.Context) {
@@ -91,13 +89,6 @@ func (p *PlayerHandler) TransmitIntelligence(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
-		return
-	}
-
-	intelligenceType := enums.ToString(req.IntelligenceType)
-
-	if intelligenceType == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid intelligence type"})
 		return
 	}
 
@@ -122,8 +113,7 @@ func (p *PlayerHandler) TransmitIntelligence(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"result":  ret,
-		"message": enums.ToString(req.IntelligenceType) + " intelligence transmitted",
+		"result": ret,
 	})
 }
 

--- a/Backend/service/repository/card_repository.go
+++ b/Backend/service/repository/card_repository.go
@@ -9,13 +9,14 @@ import (
 
 type Card struct {
 	gorm.Model
-	Id          int `gorm:"primaryKey;auto_increment"`
-	Name        string
-	Color       string
-	PlayerCards []PlayerCard
-	CreatedAt   time.Time `gorm:"autoCreateTime"`
-	UpdatedAt   time.Time `gorm:"autoCreateTime"`
-	DeletedAt   gorm.DeletedAt
+	Id               int `gorm:"primaryKey;auto_increment"`
+	Name             string
+	Color            string
+	IntelligenceType int
+	PlayerCards      []PlayerCard
+	CreatedAt        time.Time `gorm:"autoCreateTime"`
+	UpdatedAt        time.Time `gorm:"autoCreateTime"`
+	DeletedAt        gorm.DeletedAt
 }
 
 type CardRepository interface {

--- a/Backend/service/repository/mysql/player_repository.go
+++ b/Backend/service/repository/mysql/player_repository.go
@@ -22,7 +22,7 @@ func (p *PlayerRepository) CreatePlayer(ctx context.Context, player *repository.
 	return player, err
 }
 
-func (p *PlayerRepository) GetPlayer(ctx context.Context, playerId int) (*repository.Player, error) {
+func (p *PlayerRepository) GetPlayerById(ctx context.Context, playerId int) (*repository.Player, error) {
 	player := new(repository.Player)
 
 	result := p.db.First(&player, "id = ?", playerId)

--- a/Backend/service/repository/player_repository.go
+++ b/Backend/service/repository/player_repository.go
@@ -24,7 +24,7 @@ type Player struct {
 
 type PlayerRepository interface {
 	CreatePlayer(ctx context.Context, player *Player) (*Player, error)
-	GetPlayer(ctx context.Context, playerId int) (*Player, error)
+	GetPlayerById(ctx context.Context, playerId int) (*Player, error)
 	GetPlayersByGameId(ctx context.Context, id int) ([]*Player, error)
 	GetPlayerWithPlayerCards(ctx context.Context, playerId int) (*Player, error)
 	GetPlayerWithGame(ctx context.Context, playerId int) (*Player, error)

--- a/Backend/service/request/game_request.go
+++ b/Backend/service/request/game_request.go
@@ -19,8 +19,7 @@ type PlayCardResponse struct {
 }
 
 type PlayCardRequest struct {
-	CardID           int `json:"card_id"`
-	IntelligenceType int `json:"intelligence_type"`
+	CardID int `json:"card_id"`
 }
 
 type AcceptCardRequest struct {

--- a/Backend/service/service/card_service.go
+++ b/Backend/service/service/card_service.go
@@ -38,7 +38,7 @@ func (c *CardService) GetCards(ctx context.Context) ([]*repository.Card, error) 
 }
 
 func (c *CardService) GetPlayerCardsByPlayerId(ctx context.Context, id int) ([]*repository.Card, error) {
-	player, err := c.PlayerRepo.GetPlayer(ctx, id)
+	player, err := c.PlayerRepo.GetPlayerById(ctx, id)
 	game, err := c.GameRepo.GetGameWithPlayers(ctx, player.GameId)
 	if err != nil {
 		return nil, err

--- a/Backend/service/service/player_service.go
+++ b/Backend/service/service/player_service.go
@@ -117,7 +117,7 @@ func (p *PlayerService) CreatePlayerCard(c context.Context, card *repository.Pla
 }
 
 func (p *PlayerService) GetPlayerById(c context.Context, id int) (*repository.Player, error) {
-	player, err := p.PlayerRepo.GetPlayer(c, id)
+	player, err := p.PlayerRepo.GetPlayerById(c, id)
 	if err != nil {
 		return nil, err
 	}

--- a/Backend/tests/e2e/player_api_test.go
+++ b/Backend/tests/e2e/player_api_test.go
@@ -100,33 +100,12 @@ func (suite *IntegrationTestSuite) TestTransmitIntelligenceE2E() {
 	_ = suite.gameServ.InitDeck(context.TODO(), game)
 	_ = suite.gameServ.DrawCardsForAllPlayers(context.TODO(), game)
 
-	suite.T().Run("it can validate intelligence type", func(t *testing.T) {
-		playerId := rand.Intn(playerCount) + 1
-		cardId := rand.Intn(playerCount)
-
-		// Request only card id
-		url := strings.ReplaceAll(api, "{player_id}", strconv.Itoa(playerId))
-		req := PlayCardRequest{CardId: cardId}
-		reqBody, _ := json.Marshal(req)
-
-		res := suite.requestJson(url, reqBody, http.MethodPost)
-
-		// Convert response body from json to map
-		resBodyAsByteArray, _ := io.ReadAll(res.Body)
-		resBody := make(map[string]interface{})
-		_ = json.Unmarshal(resBodyAsByteArray, &resBody)
-
-		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
-		assert.Equal(t, "Invalid intelligence type", resBody["message"])
-	})
-
 	suite.T().Run("it can validate card id", func(t *testing.T) {
 		playerId := rand.Intn(playerCount) + 1
-		intelligenceType := rand.Intn(3) + 1
 
 		// Request only intelligence type
 		url := strings.ReplaceAll(api, "{player_id}", strconv.Itoa(playerId))
-		req := PlayCardRequest{IntelligenceType: intelligenceType}
+		req := PlayCardRequest{}
 		reqBody, _ := json.Marshal(req)
 
 		res := suite.requestJson(url, reqBody, http.MethodPost)
@@ -143,10 +122,9 @@ func (suite *IntegrationTestSuite) TestTransmitIntelligenceE2E() {
 	suite.T().Run("it can fail when player not found", func(t *testing.T) {
 		playerId := math.MaxInt32
 		cardId := rand.Intn(playerCount)
-		intelligenceType := rand.Intn(3) + 1
 
 		url := strings.ReplaceAll(api, "{player_id}", strconv.Itoa(playerId))
-		req := PlayCardRequest{CardId: cardId, IntelligenceType: intelligenceType}
+		req := PlayCardRequest{CardId: cardId}
 		reqBody, _ := json.Marshal(req)
 
 		res := suite.requestJson(url, reqBody, http.MethodPost)
@@ -160,34 +138,12 @@ func (suite *IntegrationTestSuite) TestTransmitIntelligenceE2E() {
 		assert.Equal(t, "Player not found", resBody["message"])
 	})
 
-	suite.T().Run("it can fail when intelligence type is not valid", func(t *testing.T) {
-		playerId := rand.Intn(playerCount) + 1
-		cardId := rand.Intn(playerCount)
-		intelligenceType := math.MaxInt32
-
-		url := strings.ReplaceAll(api, "{player_id}", strconv.Itoa(playerId))
-		req := PlayCardRequest{CardId: cardId, IntelligenceType: intelligenceType}
-		reqBody, _ := json.Marshal(req)
-
-		res := suite.requestJson(url, reqBody, http.MethodPost)
-
-		// Convert response body from json to map
-		resBodyAsByteArray, _ := io.ReadAll(res.Body)
-		resBody := make(map[string]interface{})
-		_ = json.Unmarshal(resBodyAsByteArray, &resBody)
-
-		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
-		assert.Equal(t, "Invalid intelligence type", resBody["message"])
-
-	})
-
 	suite.T().Run("it can fail when player card not found", func(t *testing.T) {
 		playerId := rand.Intn(playerCount) + 1
 		cardId := math.MaxInt32
-		intelligenceType := rand.Intn(3) + 1
 
 		url := strings.ReplaceAll(api, "{player_id}", strconv.Itoa(playerId))
-		req := PlayCardRequest{CardId: cardId, IntelligenceType: intelligenceType}
+		req := PlayCardRequest{CardId: cardId}
 		reqBody, _ := json.Marshal(req)
 
 		res := suite.requestJson(url, reqBody, http.MethodPost)
@@ -203,7 +159,6 @@ func (suite *IntegrationTestSuite) TestTransmitIntelligenceE2E() {
 
 	suite.T().Run("it can fail when game is end", func(t *testing.T) {
 		playerId := rand.Intn(playerCount) + 1
-		intelligenceType := rand.Intn(3) + 1
 
 		// Get player's card
 		cards, _ := suite.playerRepo.GetPlayerWithPlayerCards(context.TODO(), playerId)
@@ -219,7 +174,7 @@ func (suite *IntegrationTestSuite) TestTransmitIntelligenceE2E() {
 		suite.gameServ.UpdateStatus(context.TODO(), game, enums.GameEnd)
 
 		url := strings.ReplaceAll(api, "{player_id}", strconv.Itoa(playerId))
-		req := PlayCardRequest{CardId: cardId, IntelligenceType: intelligenceType}
+		req := PlayCardRequest{CardId: cardId}
 		reqBody, _ := json.Marshal(req)
 
 		res := suite.requestJson(url, reqBody, http.MethodPost)
@@ -238,7 +193,6 @@ func (suite *IntegrationTestSuite) TestTransmitIntelligenceE2E() {
 
 	suite.T().Run("it can fail when not player's turn", func(t *testing.T) {
 		playerId := rand.Intn(playerCount) + 1
-		intelligenceType := rand.Intn(3) + 1
 
 		// Get player's card
 		cards, _ := suite.playerRepo.GetPlayerWithPlayerCards(context.TODO(), playerId)
@@ -251,7 +205,7 @@ func (suite *IntegrationTestSuite) TestTransmitIntelligenceE2E() {
 		suite.gameServ.UpdateCurrentPlayer(context.TODO(), game, playerId-1)
 
 		url := strings.ReplaceAll(api, "{player_id}", strconv.Itoa(playerId))
-		req := PlayCardRequest{CardId: cardId, IntelligenceType: intelligenceType}
+		req := PlayCardRequest{CardId: cardId}
 		reqBody, _ := json.Marshal(req)
 
 		res := suite.requestJson(url, reqBody, http.MethodPost)
@@ -265,9 +219,8 @@ func (suite *IntegrationTestSuite) TestTransmitIntelligenceE2E() {
 		assert.Equal(t, "尚未輪到你出牌", resBody["message"])
 	})
 
-	suite.T().Run("it can success when valid card id and intelligence type", func(t *testing.T) {
+	suite.T().Run("it can success when valid card id", func(t *testing.T) {
 		playerId := rand.Intn(playerCount) + 1
-		intelligenceType := rand.Intn(3) + 1
 
 		// Get player's card
 		cards, _ := suite.playerRepo.GetPlayerWithPlayerCards(context.TODO(), playerId)
@@ -280,7 +233,7 @@ func (suite *IntegrationTestSuite) TestTransmitIntelligenceE2E() {
 		suite.gameServ.UpdateCurrentPlayer(context.TODO(), game, playerId)
 
 		url := strings.ReplaceAll(api, "{player_id}", strconv.Itoa(playerId))
-		req := PlayCardRequest{CardId: cardId, IntelligenceType: intelligenceType}
+		req := PlayCardRequest{CardId: cardId}
 		reqBody, _ := json.Marshal(req)
 
 		res := suite.requestJson(url, reqBody, http.MethodPost)
@@ -290,14 +243,11 @@ func (suite *IntegrationTestSuite) TestTransmitIntelligenceE2E() {
 		resBody := make(map[string]interface{})
 		_ = json.Unmarshal(resBodyAsByteArray, &resBody)
 
-		msg := enums.ToString(intelligenceType) + " intelligence transmitted"
 		assert.Equal(t, http.StatusOK, res.StatusCode)
-		assert.Equal(t, msg, resBody["message"])
 		assert.Equal(t, true, resBody["result"])
 	})
 }
 
 type PlayCardRequest struct {
-	CardId           int `json:"card_id"`
-	IntelligenceType int `json:"intelligence_type"`
+	CardId int `json:"card_id"`
 }


### PR DESCRIPTION
### Why need this change? / Root cause:
The current implementation requires the intelligence_type to be sent every time an intelligence card is transmitted. By adding the intelligence_type field to the cards table, we can associate each card with its intelligence type directly in the database. This eliminates the need to send the intelligence_type every time an intelligence card is transmitted.

### Changes made:
1. Added an intelligence_type field to the cards table. This field represents the type of intelligence associated with each card. We also added seeder data for this new field.  

2. Modified the TransmitIntelligence API to remove the need to send the intelligence_type as a parameter. 

### Test Scope / Change impact:
The changes impact the cards table in the database and the TransmitIntelligence API.
