### PR TITLE
Feat: Modified the Heartbeat API to integrate with the GAAS

### DIFF
--- a/Backend/service/delivery/http/v1/heartbeat_handler.go
+++ b/Backend/service/delivery/http/v1/heartbeat_handler.go
@@ -13,7 +13,7 @@ type HeartbeatHandler struct {
 func RegisterHeartbeatHandler(opts *HeartbeatHandler) {
 	handler := &HeartbeatHandler{}
 
-	opts.Engine.GET("/api/v1/heartbeat", handler.Heartbeat)
+	opts.Engine.GET("/api/v1/health", handler.Heartbeat)
 }
 
 // Heartbeat godoc
@@ -23,7 +23,7 @@ func RegisterHeartbeatHandler(opts *HeartbeatHandler) {
 // @Accept json
 // @Produce json
 // @Success 204
-// @Router /api/v1/heartbeat [GET]
+// @Router /api/v1/health [GET]
 func (g *HeartbeatHandler) Heartbeat(c *gin.Context) {
 	c.JSON(http.StatusNoContent, http.NoBody)
 }

--- a/Backend/tests/e2e/hearbeat_api_test.go
+++ b/Backend/tests/e2e/hearbeat_api_test.go
@@ -15,12 +15,12 @@ func TestHeartbeatEndpoint(t *testing.T) {
 	router := gin.Default()
 
 	// Set up the heartbeat endpoint
-	router.GET("/api/v1/heartbeat", func(c *gin.Context) {
+	router.GET("/api/v1/health", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})
 
 	// Prepare a new HTTP request
-	req, _ := http.NewRequest("GET", "/api/v1/heartbeat", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/health", nil)
 
 	// Create a response recorder
 	res := httptest.NewRecorder()


### PR DESCRIPTION
### Why need this change? / Root cause:
To integrate our service with the GAAS platform, we need to align our Heartbeat API endpoint related to #122.

### Changes made:
- Changed the Heartbeat API endpoint from `/api/Heartbeat` to `/api/health` 

### Test Scope / Change impact:
- This change only affects the Heartbeat API endpoint. The functionality of the Heartbeat API remains the same.
- All existing tests for the Heartbeat API should still pass after this change.